### PR TITLE
Fix: Add Vercel rewrite configuration for API calls

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -1,0 +1,8 @@
+{
+  "rewrites": [
+    {
+      "source": "/api/:path*",
+      "destination": "https://todo-app-backend-vercel.vercel.app/api/:path*"
+    }
+  ]
+}


### PR DESCRIPTION
The application was experiencing network errors when deployed to Vercel because the frontend was unable to connect to the backend API. This was happening because the API calls were made to relative paths (e.g., `/api/todos`), and Vercel was not configured to forward these requests to the backend service.

This commit adds a `vercel.json` file with a rewrite rule. This rule instructs Vercel to proxy any requests made to `/api/*` to the backend service located at `https://todo-app-backend-vercel.vercel.app`. This mirrors the proxy configuration used in the local development environment and resolves the network errors in the deployed application.