### PR TITLE
feat: Use environment variable for backend URL in Vercel config

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -2,7 +2,7 @@
   "rewrites": [
     {
       "source": "/api/:path*",
-      "destination": "https://todo-app-backend-vercel.vercel.app/api/:path*"
+      "destination": "${BACKEND_URL}/api/:path*"
     }
   ]
 }


### PR DESCRIPTION
This change updates the `vercel.json` file to use a dynamic environment variable (`BACKEND_URL`) for the rewrite destination. This makes the configuration more flexible and avoids hardcoding the backend URL in the source code.

This allows the backend URL to be managed through the Vercel project settings, which is a best practice, especially for projects that might have different environments (e.g., staging, production) in the future.